### PR TITLE
fix child type match for Col

### DIFF
--- a/src/components/Col.jsx
+++ b/src/components/Col.jsx
@@ -199,4 +199,6 @@ Col.defaultProps = {
   debug: false,
 };
 
+Col.displayName = 'Col';
+
 export default Col;

--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -90,4 +90,6 @@ Container.defaultProps = {
   component: 'div',
 };
 
+Container.displayName = 'Container';
+
 export default Container;

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { createComponent } from '../utils/styled';
-import Col from './Col';
 
 const agnosticComponent = createComponent({
   propsToOmit: [
@@ -72,9 +71,10 @@ const Row = (props) => {
     children,
     ...rest
   } = props;
+
   const renderChildren = () => (
     React.Children.map(children, (child) => {
-      if (child && child.type === Col) {
+      if (child && child.type.displayName === 'Col') {
         return React.cloneElement(child, {
           gutter,
           columnDivisions,
@@ -249,5 +249,7 @@ Row.defaultProps = {
   center: false,
   fill: false,
 };
+
+Row.displayName = 'Row';
 
 export default Row;

--- a/src/components/__snapshots__/Row.test.js.snap
+++ b/src/components/__snapshots__/Row.test.js.snap
@@ -203,19 +203,6 @@ exports[`Row it mounts <Row component="span" /> 1`] = `
 `;
 
 exports[`Row it mounts Row and passes with debug prop to Col 1`] = `
-.c1 {
-  box-sizing: border-box;
-  margin: 0px;
-  max-height: 100%;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
-  order: 0;
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
-  align-self: auto;
-  border: 1px solid green;
-}
-
 .c0 {
   box-sizing: border-box;
   display: -webkit-box;
@@ -244,6 +231,19 @@ exports[`Row it mounts Row and passes with debug prop to Col 1`] = `
   -ms-flex-line-pack: stretch;
   align-content: stretch;
   border: 1px solid red;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin: 0px;
+  max-height: 100%;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+  border: 1px solid green;
 }
 
 <Row
@@ -745,18 +745,6 @@ exports[`Row it passes props down to a child that is NOT <Col /> 1`] = `
 `;
 
 exports[`Row it passes props down to a child that is a <Col /> 1`] = `
-.c1 {
-  box-sizing: border-box;
-  margin: 0px;
-  max-height: 100%;
-  -webkit-order: 0;
-  -ms-flex-order: 0;
-  order: 0;
-  -webkit-align-self: auto;
-  -ms-flex-item-align: auto;
-  align-self: auto;
-}
-
 .c0 {
   box-sizing: border-box;
   display: -webkit-box;
@@ -784,6 +772,18 @@ exports[`Row it passes props down to a child that is a <Col /> 1`] = `
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
+}
+
+.c1 {
+  box-sizing: border-box;
+  margin: 0px;
+  max-height: 100%;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
 }
 
 <Row


### PR DESCRIPTION
Closes #53 

match on `child.type.displayname` as `child.type === Col (or instanceOf Col)` is unreliable